### PR TITLE
Cleanup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
         "Wown",
         "tilemap",
         "rngs",
+        "egui",
     ],
     "files.associations": {
         "*.tile": "ron"

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -14,7 +14,7 @@ pub fn plugin(app: &mut App) {
 fn spawn_camera(mut commands: Commands) {
     commands
         .spawn((Camera2dBundle::default(), MainCamera, RigidBody::Dynamic))
-        .with_children(|p| { // TODO: does this need to be here? Move this to world or map?
+        .with_children(|p| {
             p.spawn((
                 SpatialBundle {
                     transform: Transform::from_translation(Vec3::X * 240.),

--- a/src/editor_window.rs
+++ b/src/editor_window.rs
@@ -1,14 +1,14 @@
 use std::{borrow::Cow, fs};
 
 use bevy_editor_pls::egui::Slider;
-use bevy_inspector_egui::{bevy_inspector, reflect_inspector};
+use bevy_inspector_egui::reflect_inspector;
 
-use bevy::{asset::io::AssetSource, prelude::*};
+use bevy::prelude::*;
 use bevy_editor_pls::{
-    editor_window::EditorWindow, egui::epaint::tessellator::path, AddEditorWindow,
+    editor_window::EditorWindow, AddEditorWindow,
 };
 
-use crate::map::{Team, Tile, TileDescriptor};
+use crate::map::TileDescriptor;
 
 pub fn setup(app: &mut App) {
     app.add_editor_window::<TileEditorWindow>();
@@ -104,7 +104,7 @@ impl EditorWindow for TileEditorWindow {
                 ui.text_edit_singleline(&mut rep.rep_word);
             });
             if ui.button("Go").clicked() {
-                let Ok(mut dir) = fs::read_dir("assets/tiles") else {
+                let Ok(dir) = fs::read_dir("assets/tiles") else {
                     state.error("Failed to read Dir", ClearOn::ReadDir);
                     return;
                 };
@@ -127,7 +127,7 @@ impl EditorWindow for TileEditorWindow {
                         continue;
                     };
                     let data = data.replace(&rep.find_word, &rep.rep_word);
-                    fs::write(path, &data);
+                    let _ = fs::write(path, &data);
                     state.done = true;
                 }
             }

--- a/src/map.rs
+++ b/src/map.rs
@@ -401,7 +401,7 @@ fn spawn_map(
 struct MapEntities(HashMap<IVec3, Entity>);
 
 impl MapEntities {
-    fn new() -> MapEntities {
+    fn new() -> Self {
         MapEntities(HashMap::default())
     }
 
@@ -654,7 +654,7 @@ struct TileSpriteBuilder {
 }
 
 impl TileSpriteBuilder {
-    fn new(tiles: Vec<TileDescriptor>) -> TileSpriteBuilder {
+    fn new(tiles: Vec<TileDescriptor>) -> Self {
         TileSpriteBuilder {
             seed: 0,
             tiles,
@@ -727,7 +727,7 @@ pub struct TileDescriptor {
 }
 
 impl TileDescriptor {
-    pub fn new() -> TileDescriptor {
+    pub fn new() -> Self {
         TileDescriptor {
             priority: 0,
             tile: Tile::Air,


### PR DESCRIPTION
1. Replaced return types to `Self` where applicable.
2. Added spelling.
3. Cleaned up imports
4. Removed unnecessary `mut`.
5. Ignoring unused return.